### PR TITLE
'page' event not being fired by datatables when clicking on the page numbers

### DIFF
--- a/BS3/assets/js/datatables.js
+++ b/BS3/assets/js/datatables.js
@@ -77,8 +77,9 @@ $.extend( $.fn.dataTableExt.oPagination, {
 						.insertBefore( $('li:last', an[i])[0] )
 						.bind('click', function (e) {
 							e.preventDefault();
-							oSettings._iDisplayStart = (parseInt($('a', this).text(),10)-1) * oPaging.iLength;
-							fnDraw( oSettings );
+							if ( oSettings.oApi._fnPageChange(oSettings, parseInt($('a', this).text(),10)-1) ) {
+								fnDraw( oSettings );
+							}
 						} );
 				}
 				if ( oPaging.iPage === 0 ) {
@@ -273,8 +274,9 @@ $.extend( $.fn.dataTableExt.oPagination, {
 				var an = oSettings.aanFeatures.p;
 				var fnBind = function (j) {
 					oSettings.oApi._fnBindAction( this, {"page": j+iStartButton-1}, function(e) {
-						oSettings.oApi._fnPageChange( oSettings, e.data.page );
-						fnCallbackDraw( oSettings );
+						if( oSettings.oApi._fnPageChange( oSettings, e.data.page ) ){
+							fnCallbackDraw( oSettings );
+						}
 						e.preventDefault();
 					} );
 				};
@@ -336,8 +338,9 @@ $.extend( $.fn.dataTableExt.oPagination, {
 						.insertBefore($('li:eq(-2)', an[i]))
 						.bind('click', function (e) {
 							e.preventDefault();
-							oSettings._iDisplayStart = (parseInt($('a', this).text(),10)-1) * oPaging.iLength;
-							fnCallbackDraw( oSettings );
+							if ( oSettings.oApi._fnPageChange(oSettings, parseInt($('a', this).text(),10)-1) ) {
+								fnCallbackDraw( oSettings );
+							}
 						});
 				}
 			}

--- a/BS3/assets/js/datatables.js
+++ b/BS3/assets/js/datatables.js
@@ -158,6 +158,7 @@ $.extend( $.fn.dataTableExt.oPagination, {
 				var oLang = oSettings.oLanguage.oPaginate;
 				var oClasses = oSettings.oClasses;
 				var fnClickHandler = function ( e ) {
+					e.preventDefault()
 					if ( oSettings.oApi._fnPageChange( oSettings, e.data.action ) )
 					{
 						fnCallbackDraw( oSettings );

--- a/BS3/examples/js/datatables.js
+++ b/BS3/examples/js/datatables.js
@@ -77,8 +77,9 @@ $.extend( $.fn.dataTableExt.oPagination, {
 						.insertBefore( $('li:last', an[i])[0] )
 						.bind('click', function (e) {
 							e.preventDefault();
-							oSettings._iDisplayStart = (parseInt($('a', this).text(),10)-1) * oPaging.iLength;
-							fnDraw( oSettings );
+							if ( oSettings.oApi._fnPageChange(oSettings, parseInt($('a', this).text(),10)-1) ) {
+								fnDraw( oSettings );
+							}
 						} );
 				}
 				if ( oPaging.iPage === 0 ) {
@@ -273,8 +274,9 @@ $.extend( $.fn.dataTableExt.oPagination, {
 				var an = oSettings.aanFeatures.p;
 				var fnBind = function (j) {
 					oSettings.oApi._fnBindAction( this, {"page": j+iStartButton-1}, function(e) {
-						oSettings.oApi._fnPageChange( oSettings, e.data.page );
-						fnCallbackDraw( oSettings );
+						if ( oSettings.oApi._fnPageChange( oSettings, e.data.page ) ) {
+							fnCallbackDraw( oSettings );
+						}
 						e.preventDefault();
 					} );
 				};
@@ -336,8 +338,9 @@ $.extend( $.fn.dataTableExt.oPagination, {
 						.insertBefore('li:eq(-2)', an[i])
 						.bind('click', function (e) {
 							e.preventDefault();
-							oSettings._iDisplayStart = (parseInt($('a', this).text(),10)-1) * oPaging.iLength;
-							fnCallbackDraw( oSettings );
+							if ( oSettings.oApi._fnPageChange(oSettings, parseInt($('a', this).text(),10)-1) ) {
+								fnCallbackDraw( oSettings );
+							}
 						});
 				}
 			}

--- a/BS3/examples/js/datatables.js
+++ b/BS3/examples/js/datatables.js
@@ -158,6 +158,7 @@ $.extend( $.fn.dataTableExt.oPagination, {
 				var oLang = oSettings.oLanguage.oPaginate;
 				var oClasses = oSettings.oClasses;
 				var fnClickHandler = function ( e ) {
+					e.preventDefault()
 					if ( oSettings.oApi._fnPageChange( oSettings, e.data.action ) )
 					{
 						fnCallbackDraw( oSettings );

--- a/BS3/examples/pagination_normal.html
+++ b/BS3/examples/pagination_normal.html
@@ -460,6 +460,9 @@
 				// LENGTH - Inline-Form control
 				var length_sel = datatable.closest('.dataTables_wrapper').find('div[id$=_length] select');
 				length_sel.addClass('form-control input-sm');
+                datatable.bind('page', function(e){
+                    window.console && console.log('pagination event:', e) //this event must be fired whenever you paginate
+                });
 			});
 		});
 		</script>


### PR DESCRIPTION
_fnPageChange must be called every time you paginate because it fires the 'page' event which other plugins depend upon.

also, only redraw when needed.
