### PR TITLE
defined datatables as an AMD dependency

### DIFF
--- a/BS3/assets/js/datatables.js
+++ b/BS3/assets/js/datatables.js
@@ -1,6 +1,6 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['jquery'], factory);
+        define(['jquery','datatables'], factory);
     }
     else {
         factory(jQuery);


### PR DESCRIPTION
Shouldn't Datatables-Bootstrap3 define datatables as an AMD dependency ?

I ran into issues with my project after running the RequireJS optimizer where the Datatables-Bootstrap3 script was loaded before dataTables was. (Without the RequireJS optimizier 

Config settings in the main JS module that is loaded in the browser at runtime are not read by default by the optimizer (http://requirejs.org/docs/optimization.html#mainConfigFile)

More info on the issue I had and how I solved it here :  https://github.com/ddewaele/jQueryDataTablesGrunt/issues/1
